### PR TITLE
Remove runlim from example bash files

### DIFF
--- a/experiments/acas/run-vI.sh
+++ b/experiments/acas/run-vI.sh
@@ -4,7 +4,7 @@ cd $SCRIPT_DIR/../../
 
 run_ncubev () {
   mkdir -p experiments/acas/vertcas-pra$2-vI
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim -r 14000 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acas/property-$1-compressed-vI test/parsing/examples/acas/fixed-vI test/parsing/examples/acas/mapping test/networks/VertCAS_pra${2}_v4_45HU_200.onnx experiments/acas/vertcas-pra$2-vI/vertcas-full-compressed-pra$2-vI-RERUN --approx 1 > experiments/acas/vertcas-pra$2-vI/vertcas-full-compressed-pra$2-vI-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acas/property-$1-compressed-vI test/parsing/examples/acas/fixed-vI test/parsing/examples/acas/mapping test/networks/VertCAS_pra${2}_v4_45HU_200.onnx experiments/acas/vertcas-pra$2-vI/vertcas-full-compressed-pra$2-vI-RERUN --approx 1 > experiments/acas/vertcas-pra$2-vI/vertcas-full-compressed-pra$2-vI-RERUN.log 2>&1
 }
 
 

--- a/experiments/acas/run.sh
+++ b/experiments/acas/run.sh
@@ -4,7 +4,7 @@ cd $SCRIPT_DIR/../../
 
 run_ncubev () {
   mkdir -p experiments/acas/vertcas-pra$2
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acas/property-$1-compressed test/parsing/examples/acas/fixed test/parsing/examples/acas/mapping test/networks/VertCAS_pra${2}_v4_45HU_200.onnx experiments/acas/vertcas-pra$2/vertcas-full-compressed-pra$2-RERUN --approx 1 > experiments/acas/vertcas-pra$2/vertcas-full-compressed-pra$2-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acas/property-$1-compressed test/parsing/examples/acas/fixed test/parsing/examples/acas/mapping test/networks/VertCAS_pra${2}_v4_45HU_200.onnx experiments/acas/vertcas-pra$2/vertcas-full-compressed-pra$2-RERUN --approx 1 > experiments/acas/vertcas-pra$2/vertcas-full-compressed-pra$2-RERUN.log 2>&1
 }
 
 run_ncubev "dnc" "02"

--- a/experiments/acc/run.sh
+++ b/experiments/acc/run.sh
@@ -4,27 +4,27 @@ cd $SCRIPT_DIR/../../
 
 run_ncubev () {
   mkdir -p experiments/acc/${1}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/results-approx-${2}-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/results-approx-${2}-RERUN.log 2>&1
 }
 
 run_ncubev_fallback () {
   mkdir -p experiments/acc/${1}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/results-approx-${2}-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/results-approx-${2}-RERUN.log 2>&1
 }
 
 run_ncubev_fallback () {
   mkdir -p experiments/acc/${1}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula-fallback test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/fallback-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/fallback-approx-${2}-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula-fallback test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/fallback-approx-${2}-RERUN --approx ${2} > experiments/acc/${1}/fallback-approx-${2}-RERUN.log 2>&1
 }
 
 run_ncubev_linear () {
   mkdir -p experiments/acc/${1}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-linear-RERUN --linear > experiments/acc/${1}/results-linear-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-linear-RERUN --linear > experiments/acc/${1}/results-linear-RERUN.log 2>&1
 }
 
 run_ncubev_fallback_linear () {
   mkdir -p experiments/acc/${1}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula-fallback test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/fallback-linear-RERUN --approx 1 --linear > experiments/acc/${1}/fallback-linear-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula-fallback test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/fallback-linear-RERUN --approx 1 --linear > experiments/acc/${1}/fallback-linear-RERUN.log 2>&1
 }
 
 run_ncubev_linear "acc-2000000-64-64-64-64"

--- a/experiments/zeppelin/run.sh
+++ b/experiments/zeppelin/run.sh
@@ -4,7 +4,7 @@ cd $SCRIPT_DIR/../../
 
 run_ncubev () {
   mkdir -p experiments/zeppelin/${2}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/formula-smaller-precise test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/fixed${1} test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/mapping test/networks/${2}.onnx experiments/zeppelin/${2}/result${1}-approx-1-RERUN --approx 1 --no-cores --no-normalization > experiments/zeppelin/${2}/result${1}-approx-1-RERUN.log 2>&1
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/formula-smaller-precise test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/fixed${1} test/parsing/examples/zeppelinAvoidanceSmallStateSpace-fixedC/mapping test/networks/${2}.onnx experiments/zeppelin/${2}/result${1}-approx-1-RERUN --approx 1 --no-cores --no-normalization > experiments/zeppelin/${2}/result${1}-approx-1-RERUN.log 2>&1
 }
 
 run_ncubev "40" "zeppelin-1400000-8-8"

--- a/run_example.sh
+++ b/run_example.sh
@@ -15,7 +15,7 @@ run_ncubev () {
   # test/networks/${1}.onnx             -> ONNX file of the network
   # experiments/acc/${1}/results-approx-${2} -> Prefix of the output files (long runs store intermediate results to save RAM)
   # --approx ${2}                       -> Approximation level \in {1,2,3}
-  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 runlim ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2}
+  OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./deps/NCubeV/bin/NCubeV test/parsing/examples/acc/formula test/parsing/examples/acc/fixed test/parsing/examples/acc/mapping test/networks/${1}.onnx experiments/acc/${1}/results-approx-${2}-RERUN --approx ${2}
 }
 
 run_ncubev "acc-2000000-64-64-64-64" "1"


### PR DESCRIPTION
This is to make it easier to run the software since I do not want to add runlim as an explicit dependency of the project.